### PR TITLE
Response bank burst support

### DIFF
--- a/dv/simmem_resp_bank/cpp/simmem_resp_bank_tb.cc
+++ b/dv/simmem_resp_bank/cpp/simmem_resp_bank_tb.cc
@@ -113,6 +113,7 @@ class WriteRespBankTestbench {
   void simmem_reservation_start(uint32_t axi_id) {
     module_->rsv_valid_i = 1;
     module_->rsv_req_id_onehot_i = 1 << axi_id;
+    module_->rsv_burst_len_i = 4;
   }
 
   /**


### PR DESCRIPTION
Implements burst support in response banks.

Also, ```update_t_from_ram_q``` has been renamed to ```update_pt_from_ram_q```. It was an artifact naming mistake that remained unseen.