### PR TITLE
Corrections for delay inaccuracies 

### DIFF
--- a/dv/simmem_top/cpp/simmem_top_tb.cc
+++ b/dv/simmem_top/cpp/simmem_top_tb.cc
@@ -450,7 +450,7 @@ class RealMemoryController {
       new_rdata.id = raddr.id;
       new_rdata.data = raddr.addr + i;
       new_rdata.rsp = 0;  // "OK" response
-      new_rdata.last = i == raddr.burst_len - 1;
+      new_rdata.last = i == raddr.burst_len;
       rdata_out_queues[raddr.id].push(new_rdata);
     }
   }

--- a/rtl/simmem_delay_calculator.sv
+++ b/rtl/simmem_delay_calculator.sv
@@ -108,11 +108,11 @@ module simmem_delay_calculator #(
       wdata_immediate_cnt = 0;
       if (!wdata_cnt_d[MaxPendingWDataW]) begin
         // If wdata_cnt_d is nonnegative, then consider sending immediate data
-        if (AxLenWidth'(wdata_cnt_d) >= waddr_i.burst_len) begin
+        if (AxLenWidth'(wdata_cnt_d) >= get_effective_burst_len(waddr_i.burst_len)) begin
           // If wdata_cnt_d is nonnegative and all the data associated with the address has arrived
           // not later than the address, then transmit all this data with the address request to the
           // delay calculator core.
-          wdata_immediate_cnt = waddr_i.burst_len[MaxBurstLenField - 1:0];
+          wdata_immediate_cnt = get_effective_burst_len(waddr_i.burst_len);
         end else begin
           // Else, transmit only the already and currently received write data, and set the counter
           // to zero, as it has been emptied.
@@ -121,7 +121,7 @@ module simmem_delay_calculator #(
       end
 
       // Update the write data count to take the new core demand into account.
-      wdata_cnt_d = wdata_cnt_d - MaxPendingWDataW'(waddr_i.burst_len);
+      wdata_cnt_d = wdata_cnt_d - MaxPendingWDataW'(get_effective_burst_len(waddr_i.burst_len));
     end
   end
 

--- a/rtl/simmem_delay_calculator_core.sv
+++ b/rtl/simmem_delay_calculator_core.sv
@@ -806,7 +806,7 @@ module simmem_delay_calculator_core #(
           // write data to come in. The rest of the data_v bits (between the two possibly empty
           // ranges of ones) are set to zero, awaiting further write data requests.
           wslt_d[i_slt].data_v[i_bit] =
-              (i_bit >= get_effective_burst_len(AxLenWidth'(waddr_i.burst_len))) || (i_bit < get_effective_burst_len(AxLenWidth'(wdata_immediate_cnt_i)));
+              (i_bit >= get_effective_burst_len(AxLenWidth'(waddr_i.burst_len))) || (i_bit < AxLenWidth'(wdata_immediate_cnt_i));
           // The age matrix has to be updated for each immediate write data, with the same age
           // relative to the entries external to the slot.
           main_new_entry[i_slt * MaxBurstEffLen+i_bit] = i_bit < wdata_immediate_cnt_i;
@@ -931,7 +931,7 @@ module simmem_delay_calculator_core #(
         for (int unsigned i_slt = 0; i_slt < NumWSlots; i_slt = i_slt + 1) begin
           for (int unsigned i_bit = 0; i_bit < MaxBurstEffLen; i_bit = i_bit + 1) begin
             // Mark memory operation done if already done, or was pending.
-            wslt_d[i_slt].mem_done[i_bit] = wslt_q[i_slt].mem_done[i_bit] |
+            wslt_d[i_slt].mem_done[i_bit] = wslt_d[i_slt].mem_done[i_bit] |
                 (wslt_q[i_slt].mem_pending[i_bit] &
                 (get_assigned_rk_id(slt_waddrs[i_slt][i_bit])==NumRksW'(i_rk)));
             // Unset the potential corresponding memory pending bit.
@@ -942,7 +942,7 @@ module simmem_delay_calculator_core #(
         for (int unsigned i_slt = 0; i_slt < NumRSlots; i_slt = i_slt + 1) begin
           for (int unsigned i_bit = 0; i_bit < MaxBurstEffLen; i_bit = i_bit + 1) begin
             // Mark memory operation done if already done, or was pending.
-            rslt_d[i_slt].mem_done[i_bit] = rslt_q[i_slt].mem_done[i_bit] |
+            rslt_d[i_slt].mem_done[i_bit] = rslt_d[i_slt].mem_done[i_bit] |
                 (rslt_q[i_slt].mem_pending[i_bit] &
                 (get_assigned_rk_id(slt_raddrs[i_slt][i_bit])==NumRksW'(i_rk)));
             // Unset the potential corresponding memory pending bit.


### PR DESCRIPTION
Hello,

Some inaccuracies appeared in the actual delays between request and response.
These changes solve the issue, solving precisely:
* A confusion due to the burst length field value being 1 unit lower than the effective burst length, and which impaired compatibility between the delay calculator and its wrapper.
* A rare occurrence of the value wslt_d or rslt_d being overwritten during a combinatorial block. 