### PR TITLE
AXI corrections

### DIFF
--- a/dv/simmem_top/cpp/simmem_axi_dimensions.h
+++ b/dv/simmem_top/cpp/simmem_axi_dimensions.h
@@ -25,9 +25,9 @@ const uint64_t AxAddrWidth = GlobalMemCapaW;
 const uint64_t AxLenWidth = 8;
 const uint64_t AxSizeWidth = 3;
 const uint64_t AxBurstWidth = 2;
-const uint64_t AxLockWidth = 2;
+const uint64_t AxLockWidth = 1;
 const uint64_t AxCacheWidth = 4;
-const uint64_t AxProtWidth = 4;
+const uint64_t AxProtWidth = 3;
 const uint64_t AxQoSWidth = 4;
 const uint64_t AxRegionWidth = 4;
 const uint64_t AwUserWidth = 0;
@@ -38,7 +38,7 @@ const uint64_t XLastWidth = 1;
 // XReespWidth may be increased to 10 when testing, to have wider patterns to
 // compare. This modification has to be performed in rtl/simmem_pkg
 // simultaneously.
-const uint64_t XRespWidth = 3;
+const uint64_t XRespWidth = 2;
 const uint64_t WUserWidth = 0;
 const uint64_t RUserWidth = 0;
 const uint64_t BUserWidth = 0;
@@ -48,6 +48,7 @@ const uint64_t MaxBurstSizeField = 2;
 
 // Effective max burst size (in number of elements)
 const uint64_t MaxBurstEffSizeBytes = 1 << MaxBurstSizeField;
+const uint64_t MaxBurstEffSizeBits = MaxBurstEffSizeBytes * 8;
 const uint64_t WStrbWidth = MaxBurstEffSizeBytes;
 
 // Maximal width of a single AXI message.

--- a/dv/simmem_top/cpp/simmem_axi_structures.cc
+++ b/dv/simmem_top/cpp/simmem_axi_structures.cc
@@ -30,12 +30,12 @@ const uint64_t ReadAddress::region_w = AxQoSWidth;
 const uint64_t WriteResponse::id_w = IDWidth;
 const uint64_t WriteResponse::rsp_w = XRespWidth;
 
-const uint64_t WriteData::data_w = MaxBurstEffSizeBytes;
+const uint64_t WriteData::data_w = MaxBurstEffSizeBits;
 const uint64_t WriteData::strb_w = WStrbWidth;
 const uint64_t WriteData::last_w = XLastWidth;
 
 const uint64_t ReadData::id_w = IDWidth;
-const uint64_t ReadData::data_w = MaxBurstEffSizeBytes;
+const uint64_t ReadData::data_w = MaxBurstEffSizeBits;
 const uint64_t ReadData::rsp_w = XRespWidth;
 const uint64_t ReadData::last_w = XLastWidth;
 

--- a/fusesoc.conf
+++ b/fusesoc.conf
@@ -1,0 +1,6 @@
+[library.simmem]
+location = /home/ppr/gsoc/gsoc-sim-mem
+sync-uri = .
+sync-type = local
+auto-sync = true
+

--- a/rtl/simmem_delay_calculator.sv
+++ b/rtl/simmem_delay_calculator.sv
@@ -75,14 +75,14 @@ module simmem_delay_calculator #(
 
   // Counters for the write data without address yet. If negative, then it means, that the core is
   // still awaiting data write data.
-  logic signed [MaxPendingWDataW:0] wdata_cnt_d;
-  logic signed [MaxPendingWDataW:0] wdata_cnt_q;
+  logic signed [MaxPendingWDataW-1:0] wdata_cnt_d;
+  logic signed [MaxPendingWDataW-1:0] wdata_cnt_q;
 
   // Valid signal for the write data from the delay calculator core.
   logic core_wdata_valid_input;
   // Determines whether the core is ready to receive new data.
   logic core_wdata_ready;
-  assign core_wdata_ready = wdata_cnt_q[MaxPendingWDataW];
+  assign core_wdata_ready = wdata_cnt_q[MaxPendingWDataW-1];
 
   // Counts how many data requests have been received before or with the write address request.
   logic [MaxBurstLenField-1:0] wdata_immediate_cnt;
@@ -106,7 +106,7 @@ module simmem_delay_calculator #(
       // data coming in during the same cycle as the address. Safety of this operation is granted by
       // the order in which wdata_cnt_d is updated in the combinatorial block.
       wdata_immediate_cnt = 0;
-      if (!wdata_cnt_d[MaxPendingWDataW]) begin
+      if (!wdata_cnt_d[MaxPendingWDataW-1]) begin
         // If wdata_cnt_d is nonnegative, then consider sending immediate data
         if (AxLenWidth'(wdata_cnt_d) >= get_effective_burst_len(waddr_i.burst_len)) begin
           // If wdata_cnt_d is nonnegative and all the data associated with the address has arrived

--- a/rtl/simmem_delay_calculator_core.sv
+++ b/rtl/simmem_delay_calculator_core.sv
@@ -663,16 +663,12 @@ module simmem_delay_calculator_core #(
   for (genvar i_slt = 0; i_slt < NumWSlots; i_slt = i_slt + 1) begin : gen_waddrs_perslt
     for (genvar i_bit = 0; i_bit < MaxBurstEffLen; i_bit = i_bit + 1) begin : gen_waddrs
       if (i_bit == 0) begin
-        assign slt_waddr_lsbs[i_slt][0] = wslt_q[i_slt].addr[BurstAddrLSBs-1:0];
+        assign slt_waddr_lsbs[i_slt][0] = BurstAddrLSBs'(wslt_q[i_slt].addr);
       end else begin
-        always_comb begin
-          if (wslt_q[i_slt].burst_fixed) begin
-            assign slt_waddr_lsbs[i_slt][i_bit] = wslt_q[i_slt].addr[BurstAddrLSBs-1:0];
-          end else begin
-            assign slt_waddr_lsbs[i_slt][i_bit] = BurstAddrLSBs'(slt_waddr_lsbs[i_slt][i_bit - 1] +
-                BurstAddrLSBs'(get_effective_burst_size(AxSizeWidth'(wslt_q[i_slt].burst_size))));
-          end
-        end
+        assign slt_waddr_lsbs[i_slt][i_bit] =
+            wslt_q[i_slt].burst_fixed ? BurstAddrLSBs'(wslt_q[i_slt].addr) :
+            BurstAddrLSBs'(slt_waddr_lsbs[i_slt][i_bit - 1] +
+            BurstAddrLSBs'(get_effective_burst_size(AxSizeWidth'(wslt_q[i_slt].burst_size))));
       end
 
       // Concatenate the MSBs of the base address with the LSBs of each entry to form the whole
@@ -688,13 +684,13 @@ module simmem_delay_calculator_core #(
   for (genvar i_slt = 0; i_slt < NumRSlots; i_slt = i_slt + 1) begin : gen_raddrs_perslt
     for (genvar i_bit = 0; i_bit < MaxBurstEffLen; i_bit = i_bit + 1) begin : gen_raddrs
       if (i_bit == 0) begin
-        assign slt_raddr_lsbs[i_slt][0] = rslt_q[i_slt].addr[BurstAddrLSBs-1:0];
+        assign slt_raddr_lsbs[i_slt][0] = BurstAddrLSBs'(rslt_q[i_slt].addr);
       end else begin
         always_comb begin
           if (rslt_q[i_slt].burst_fixed) begin
-            assign slt_raddr_lsbs[i_slt][i_bit] = rslt_q[i_slt].addr[BurstAddrLSBs-1:0];
+            slt_raddr_lsbs[i_slt][i_bit] = BurstAddrLSBs'(rslt_q[i_slt].addr);
           end else begin
-            assign slt_raddr_lsbs[i_slt][i_bit] = BurstAddrLSBs'(slt_raddr_lsbs[i_slt][i_bit - 1] +
+            slt_raddr_lsbs[i_slt][i_bit] = BurstAddrLSBs'(slt_raddr_lsbs[i_slt][i_bit - 1] +
                 BurstAddrLSBs'(get_effective_burst_size(AxSizeWidth'(rslt_q[i_slt].burst_size))));
           end
         end

--- a/rtl/simmem_pkg.sv
+++ b/rtl/simmem_pkg.sv
@@ -86,9 +86,9 @@ package simmem_pkg;
   parameter int unsigned AxLenWidth = 8;
   parameter int unsigned AxSizeWidth = 3;
   parameter int unsigned AxBurstWidth = 2;
-  parameter int unsigned AxLockWidth = 2;
+  parameter int unsigned AxLockWidth = 1;
   parameter int unsigned AxCacheWidth = 4;
-  parameter int unsigned AxProtWidth = 4;
+  parameter int unsigned AxProtWidth = 3;
   parameter int unsigned AxQoSWidth = 4;
   parameter int unsigned AxRegionWidth = 4;
   parameter int unsigned AwUserWidth = 0;
@@ -154,15 +154,15 @@ package simmem_pkg;
     // logic [WUserWidth-1:0] user_signal;
     logic [XLastWidth-1:0] last;
     logic [WStrbWidth-1:0] strobes;
-    logic [MaxBurstEffSizeBytes-1:0] data;
+    logic [MaxBurstEffSizeBits-1:0] data;
   // logic [IDWidth-1:0] id; AXI4 does not allocate identifiers in write data messages
   } wdata_t;
 
   typedef struct packed {
     // logic [RUserWidth-1:0] user_signal;
     logic [XLastWidth-1:0] last;
-    logic [WStrbWidth-1:0] response;
-    logic [MaxBurstEffSizeBytes-1:0] data;
+    logic [XRespWidth-1:0] response;
+    logic [MaxBurstEffSizeBits-1:0] data;
     logic [IDWidth-1:0] id;
   } rdata_all_fields_t;
 

--- a/rtl/simmem_top_wrapper.v
+++ b/rtl/simmem_top_wrapper.v
@@ -1,0 +1,406 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Simulated memory controller top-level Verilog wrapper
+
+// This is a Verilog wrapper to integrate the module as a block in Xilinx Vivado.
+
+module simmem_top_wrapper #(
+    // Width of the main memory capacity, i.e., of an address in main memory.
+    parameter GlobalMemCapaW = 19,
+    // Main memory capacity, in bytes.
+    parameter GlobalMemCapa = 1 << GlobalMemCapaW,
+
+    /////////////////
+    // AXI signals //
+    /////////////////
+
+    parameter IDWidth = 2,
+    parameter NumIds = 1 << IDWidth,
+    // No ID tag in the write data
+    parameter WIDWidth = 0,
+
+    // Address field widths
+    parameter AxAddrWidth = GlobalMemCapaW,
+    parameter AxLenWidth = 8,
+    parameter AxSizeWidth = 3,
+    parameter AxBurstWidth = 2,
+    parameter AxLockWidth = 1,
+    parameter AxCacheWidth = 4,
+    parameter AxProtWidth = 3,
+    parameter AxQoSWidth = 4,
+    parameter AxRegionWidth = 4,
+    parameter AwUserWidth = 0,
+    parameter ArUserWidth = 0,
+
+    // Data & response field widths
+    parameter MaxBurstSizeField = 2,
+    parameter MaxBurstEffSizeBytes = 1 << MaxBurstSizeField,
+    parameter MaxBurstEffSizeBits = MaxBurstEffSizeBytes * 8,
+
+    parameter XLastWidth = 1,
+    parameter XRespWidth = 2,
+    parameter WUserWidth = 0,
+    parameter RUserWidth = 0,
+    parameter BUserWidth = 0,
+
+    parameter WStrbWidth = MaxBurstEffSizeBytes,
+
+    parameter WriteAddrWidth = IDWidth + AxAddrWidth + AxLenWidth + AxSizeWidth + AxBurstWidth + AxLockWidth + AxCacheWidth + AxProtWidth + AxRegionWidth + AxQoSWidth,// + AxUserWidth,
+    parameter ReadAddrWidth  = IDWidth + AxAddrWidth + AxLenWidth + AxSizeWidth + AxBurstWidth + AxLockWidth + AxCacheWidth + AxProtWidth + AxRegionWidth + AxQoSWidth,// + AxUserWidth,
+    parameter WriteDataWidth = MaxBurstEffSizeBits + WStrbWidth + XLastWidth,
+    parameter ReadDataWidth  = IDWidth + MaxBurstEffSizeBits + XRespWidth-1 + XLastWidth,
+    parameter WriteRespWidth = IDWidth + XRespWidth-1
+  ) (
+    input clk_i,
+    input rst_ni,
+
+    // Normally AXI is automatically inferred.  However, if the names of
+    // your ports do not match, you can force the
+    // the creation of an interface and map the physical ports to the
+    // logical ports by using the X_INTERFACE_INFO
+    // attribute before each physical port
+    // Typical parameters the user might specify: PROTOCOL {AXI4, AXI4LITE,
+    // AXI3}, SUPPORTS_NARROW_BURST {0, 1}, NUM_READ_OUTSTANDING,
+    // NUM_WRITE_OUTSTANDING, MAX_BURST_LENGTH
+    // The PROTOCOL can typically be inferred from the set of signals.
+    // aximm - AMBA AXI Interface (slave directions)
+    //
+    // Allowed parameters:
+    //  CLK_DOMAIN                - Clk Domain                (string default: <blank>)
+    //  PHASE                     - Phase                     (float)
+    //  MAX_BURST_LENGTH          - Max Burst Length          (long default: 256) [1, 256]
+    //  NUM_WRITE_OUTSTANDING     - Num Write Outstanding     (long default: 1) [0, 32]
+    //  NUM_READ_OUTSTANDING      - Num Read Outstanding      (long default: 1) [0, 32]
+    //  SUPPORTS_NARROW_BURST     - Supports Narrow Burst     (long default: 1) [0, 1]
+    //  READ_WRITE_MODE           - Read Write Mode           (string default: READ_WRITE) {READ_WRITE,READ_ONLY,WRITE_ONLY}
+    //  BUSER_WIDTH               - Buser Width               (long)
+    //  RUSER_WIDTH               - Ruser Width               (long)
+    //  WUSER_WIDTH               - Wuser Width               (long)
+    //  ARUSER_WIDTH              - Aruser Width              (long)
+    //  AWUSER_WIDTH              - Awuser Width              (long)
+    //  ADDR_WIDTH                - Addr Width                (long default: 32) [1, 64]
+    //  ID_WIDTH                  - Id Width                  (long)
+    //  FREQ_HZ                   - Frequency                 (float default: 100000000)
+    //  PROTOCOL                  - Protocol                  (string default: AXI4) {AXI4,AXI4LITE,AXI3}
+    //  DATA_WIDTH                - Data Width                (long default: 32) {32,64,128,256,512,1024}
+    //  HAS_BURST                 - Has BURST                 (long default: 1) {0,1}
+    //  HAS_CACHE                 - Has CACHE                 (long default: 1) {0,1}
+    //  HAS_LOCK                  - Has LOCK                  (long default: 1) {0,1}
+    //  HAS_PROT                  - Has PROT                  (long default: 1) {0,1}
+    //  HAS_QOS                   - Has QOS                   (long default: 1) {0,1}
+    //  HAS_REGION                - Has REGION                (long default: 1) {0,1}
+    //  HAS_WSTRB                 - Has WSTRB                 (long default: 1) {0,1}
+    //  HAS_BRESP                 - Has BRESP                 (long default: 1) {0,1}
+    //  HAS_RRESP                 - Has RRESP                 (long default: 1) {0,1}
+  // Uncomment the following to set interface specific parameter on the bus interface.
+  //  (* X_INTERFACE_PARAMETER = "CLK_DOMAIN <value>,PHASE
+  // <value>,MAX_BURST_LENGTH <value>,NUM_WRITE_OUTSTANDING
+  // <value>,NUM_READ_OUTSTANDING <value>,SUPPORTS_NARROW_BURST
+  // <value>,READ_WRITE_MODE <value>,BUSER_WIDTH <value>,RUSER_WIDTH
+  // <value>,WUSER_WIDTH <value>,ARUSER_WIDTH <value>,AWUSER_WIDTH
+  // <value>,ADDR_WIDTH <value>,ID_WIDTH <value>,FREQ_HZ <value>,PROTOCOL
+  // <value>,DATA_WIDTH <value>,HAS_BURST <value>,HAS_CACHE <value>,HAS_LOCK
+  // <value>,HAS_PROT <value>,HAS_QOS <value>,HAS_REGION <value>,HAS_WSTRB
+  // <value>,HAS_BRESP <value>,HAS_RRESP <value>" *)
+
+  // From the requester
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s AWID" *)
+  input [IDWidth-1:0] s_awid, // Write address ID
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s AWADDR" *)
+  input [AxAddrWidth-1:0] s_awaddr, // Write address
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s AWLEN" *)
+  input [AxLenWidth-1:0] s_awlen, // Burst length
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s AWSIZE" *)
+  input [AxSizeWidth-1:0] s_awsize, // Burst size
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s AWBURST" *)
+  input [AxBurstWidth-1:0] s_awburst, // Burst type
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s AWLOCK" *)
+  input [AxLockWidth-1:0] s_awlock, // Lock type
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s AWCACHE" *)
+  input [AxCacheWidth-1:0] s_awcache, // Cache type
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s AWPROT" *)
+  input [AxProtWidth-1:0] s_awprot, // Protection type
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s AWREGION" *)
+  input [AxRegionWidth-1:0] s_awregion, // Write address slave region
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s AWQOS" *)
+  input [AxQoSWidth-1:0] s_awqos, // Transaction Quality of Service token
+  // (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s AWUSER" *)
+  // input [AwUserWidth-1:0] s_awuser, // Write address user sideband (optional)
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s AWVALID" *)
+  input s_awvalid, // Write address valid
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s AWREADY" *)
+  output s_awready, // Write address ready
+  // (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s WID" *)
+  // input [WIDWidth-1:0] s_wid, // Write ID tag (optional)
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s WDATA" *)
+  input [MaxBurstEffSizeBits-1:0] s_wdata, // Write data
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s WSTRB" *)
+  input [WStrbWidth-1:0] s_wstrb, // Write strobes
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s WLAST" *)
+  input s_wlast, // Write last beat
+  // (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s WUSER" *)
+  // input [WUserWidth-1:0] s_wuser, // Write data user sideband (optional)
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s WVALID" *)
+  input s_wvalid, // Write valid
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s WREADY" *)
+  output s_wready, // Write ready
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s BID" *)
+  output [IDWidth-1:0] s_bid, // Response ID
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s BRESP" *)
+  output [1:0] s_bresp, // Write response
+  // (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s BUSER" *)
+  // output [BUserWidth-1:0] s_buser, // Write response user sideband (optional)
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s BVALID" *)
+  output s_bvalid, // Write response valid
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s BREADY" *)
+  input s_bready, // Write response ready
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s ARID" *)
+  input [IDWidth-1:0] s_arid, // Read address ID
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s ARADDR" *)
+  input [AxAddrWidth-1:0] s_araddr, // Read address
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s ARLEN" *)
+  input [AxLenWidth-1:0] s_arlen, // Burst length
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s ARSIZE" *)
+  input [AxSizeWidth-1:0] s_arsize, // Burst size
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s ARBURST" *)
+  input [AxBurstWidth-1:0] s_arburst, // Burst type
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s ARLOCK" *)
+  input [AxLockWidth-1:0] s_arlock, // Lock type
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s ARCACHE" *)
+  input [AxCacheWidth-1:0] s_arcache, // Cache type
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s ARPROT" *)
+  input [AxProtWidth-1:0] s_arprot, // Protection type
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s ARREGION" *)
+  input [AxRegionWidth-1:0] s_arregion, // Read address slave region
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s ARQOS" *)
+  input [AxQoSWidth-1:0] s_arqos, // Quality of service token
+  // (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s ARUSER" *)
+  // input [RUserWidth-1:0] s_aruser, // Read address user sideband (optional)
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s ARVALID" *)
+  input s_arvalid, // Read address valid
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s ARREADY" *)
+  output s_arready, // Read address ready
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s RID" *)
+  output [IDWidth-1:0] s_rid, // Read ID tag
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s RDATA" *)
+  output [MaxBurstEffSizeBits-1:0] s_rdata, // Read data
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s RRESP" *)
+  output [XRespWidth-1:0] s_rresp, // Read response
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s RLAST" *)
+  output s_rlast, // Read last beat
+  // (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s RUSER" *)
+  // output [RUserWidth-1:0] s_ruser, // Read user sideband (optional)
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s RVALID" *)
+  output s_rvalid, // Read valid
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 s RREADY" *)
+  input s_rready, // Read ready
+
+  // To the real memory controller
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m AWID" *)
+  output [IDWidth-1:0] m_awid, // Write address ID
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m AWADDR" *)
+  output [AxAddrWidth-1:0] m_awaddr, // Write address
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m AWLEN" *)
+  output [AxLenWidth-1:0] m_awlen, // Burst length
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m AWSIZE" *)
+  output [AxSizeWidth-1:0] m_awsize, // Burst size
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m AWBURST" *)
+  output [AxBurstWidth-1:0] m_awburst, // Burst type
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m AWLOCK" *)
+  output [AxLockWidth-1:0] m_awlock, // Lock type
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m AWCACHE" *)
+  output [AxCacheWidth-1:0] m_awcache, // Cache type
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m AWPROT" *)
+  output [AxProtWidth-1:0] m_awprot, // Protection type
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m AWREGION" *)
+  output [AxRegionWidth-1:0] m_awregion, // Write address slave region
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m AWQOS" *)
+  output [AxQoSWidth-1:0] m_awqos, // Transaction Quality of Service token
+  // (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m AWUSER" *)
+  // output [AwUserWidth-1:0] m_awuser, // Write address user sideband (optional)
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m AWVALID" *)
+  output m_awvalid, // Write address valid
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m AWREADY" *)
+  input m_awready, // Write address ready
+  // (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m WID" *)
+  // output [WIDWidth-1:0] m_wid, // Write ID tag (optional)
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m WDATA" *)
+  output [MaxBurstEffSizeBits-1:0] m_wdata, // Write data
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m WSTRB" *)
+  output [WStrbWidth-1:0] m_wstrb, // Write strobes
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m WLAST" *)
+  output m_wlast, // Write last beat
+  // (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m WUSER" *)
+  // output [WUserWidth-1:0] m_wuser, // Write data user sideband (optional)
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m WVALID" *)
+  output m_wvalid, // Write valid
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m WREADY" *)
+  input m_wready, // Write ready
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m BID" *)
+  input [IDWidth-1:0] m_bid, // Response ID
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m BRESP" *)
+  input [1:0] m_bresp, // Write response
+  // (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m BUSER" *)
+  // input [BUserWidth-1:0] m_buser, // Write response user sideband (optional)
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m BVALID" *)
+  input m_bvalid, // Write response valid
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m BREADY" *)
+  output m_bready, // Write response ready
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m ARID" *)
+  output [IDWidth-1:0] m_arid, // Read address ID
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m ARADDR" *)
+  output [AxAddrWidth-1:0] m_araddr, // Read address
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m ARLEN" *)
+  output [AxLenWidth-1:0] m_arlen, // Burst length
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m ARSIZE" *)
+  output [AxSizeWidth-1:0] m_arsize, // Burst size
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m ARBURST" *)
+  output [AxBurstWidth-1:0] m_arburst, // Burst type
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m ARLOCK" *)
+  output [AxLockWidth-1:0] m_arlock, // Lock type
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m ARCACHE" *)
+  output [AxCacheWidth-1:0] m_arcache, // Cache type
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m ARPROT" *)
+  output [AxProtWidth-1:0] m_arprot, // Protection type
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m ARREGION" *)
+  output [AxRegionWidth-1:0] m_arregion, // Read address slave region
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m ARQOS" *)
+  output [AxQoSWidth-1:0] m_arqos, // Quality of service token
+  // (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m ARUSER" *)
+  // output [RUserWidth-1:0] m_aruser, // Read address user sideband (optional)
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m ARVALID" *)
+  output m_arvalid, // Read address valid
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m ARREADY" *)
+  input m_arready, // Read address ready
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m RID" *)
+  input [IDWidth-1:0] m_rid, // Read ID tag
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m RDATA" *)
+  input [MaxBurstEffSizeBits-1:0] m_rdata, // Read data
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m RRESP" *)
+  input [XRespWidth-1:0] m_rresp, // Read response
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m RLAST" *)
+  input m_rlast, // Read last beat
+  // (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m RUSER" *)
+  // input [RUserWidth-1:0] m_ruser, // Read user sideband (optional)
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m RVALID" *)
+  input m_rvalid, // Read valid
+  (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 m RREADY" *)
+  output m_rready // Read ready
+);
+
+  wire [WriteAddrWidth-1:0] s_waddr_internal;
+  wire [WriteAddrWidth-1:0] m_waddr_internal;
+  wire [ReadAddrWidth-1:0] s_raddr_internal;
+  wire [ReadAddrWidth-1:0] m_raddr_internal;
+  wire [WriteDataWidth-1:0] s_wdata_internal;
+  wire [WriteDataWidth-1:0] m_wdata_internal;
+  wire [ReadDataWidth-1:0] s_rdata_internal;
+  wire [ReadDataWidth-1:0] m_rdata_internal;
+  wire [WriteRespWidth-1:0] s_wrsp_internal;
+  wire [WriteRespWidth-1:0] m_wrsp_internal;
+
+  assign s_waddr_internal[0+:IDWidth] = s_awid;
+  assign m_waddr_internal[0+:IDWidth] = m_awid;
+  assign s_waddr_internal[IDWidth+:AxAddrWidth] = s_awaddr;
+  assign m_waddr_internal[IDWidth+:AxAddrWidth] = m_awaddr;
+  assign s_waddr_internal[IDWidth+AxAddrWidth+:AxLenWidth] = s_awlen;
+  assign m_waddr_internal[IDWidth+AxAddrWidth+:AxLenWidth] = m_awlen;
+  assign s_waddr_internal[IDWidth+AxAddrWidth+AxLenWidth+:AxSizeWidth] = s_awsize;
+  assign m_waddr_internal[IDWidth+AxAddrWidth+AxLenWidth+:AxSizeWidth] = m_awsize;
+  assign s_waddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+:AxBurstWidth] = s_awburst;
+  assign m_waddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+:AxBurstWidth] = m_awburst;
+  assign s_waddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+:AxLockWidth] = s_awlock;
+  assign m_waddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+:AxLockWidth] = m_awlock;
+  assign s_waddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+:AxCacheWidth] = s_awcache;
+  assign m_waddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+:AxCacheWidth] = m_awcache;
+  assign s_waddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+AxCacheWidth+:AxProtWidth] = s_awprot;
+  assign m_waddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+AxCacheWidth+:AxProtWidth] = m_awprot;
+  assign s_waddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+AxCacheWidth+AxProtWidth+:AxRegionWidth] = s_awregion;
+  assign m_waddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+AxCacheWidth+AxProtWidth+:AxRegionWidth] = m_awregion;
+  assign s_waddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+AxCacheWidth+AxProtWidth+AxRegionWidth+:AxQoSWidth] = s_awqos;
+  assign m_waddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+AxCacheWidth+AxProtWidth+AxRegionWidth+:AxQoSWidth] = m_awqos;
+  // assign s_waddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+AxCacheWidth+AxProtWidth+AxRegionWidth+AxQoSWidth+:AxUserWidth] = s_awuser;
+  // assign m_waddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+AxCacheWidth+AxProtWidth+AxRegionWidth+AxQoSWidth+:AxUserWidth] = m_awuser;
+
+  assign s_raddr_internal[0+:IDWidth] = s_arid;
+  assign m_raddr_internal[0+:IDWidth] = m_arid;
+  assign s_raddr_internal[IDWidth+:AxAddrWidth] = s_araddr;
+  assign m_raddr_internal[IDWidth+:AxAddrWidth] = m_araddr;
+  assign s_raddr_internal[IDWidth+AxAddrWidth+:AxLenWidth] = s_arlen;
+  assign m_raddr_internal[IDWidth+AxAddrWidth+:AxLenWidth] = m_arlen;
+  assign s_raddr_internal[IDWidth+AxAddrWidth+AxLenWidth+:AxSizeWidth] = s_arsize;
+  assign m_raddr_internal[IDWidth+AxAddrWidth+AxLenWidth+:AxSizeWidth] = m_arsize;
+  assign s_raddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+:AxBurstWidth] = s_arburst;
+  assign m_raddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+:AxBurstWidth] = m_arburst;
+  assign s_raddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+:AxLockWidth] = s_arlock;
+  assign m_raddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+:AxLockWidth] = m_arlock;
+  assign s_raddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+:AxCacheWidth] = s_arcache;
+  assign m_raddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+:AxCacheWidth] = m_arcache;
+  assign s_raddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+AxCacheWidth+:AxProtWidth] = s_arprot;
+  assign m_raddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+AxCacheWidth+:AxProtWidth] = m_arprot;
+  assign s_raddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+AxCacheWidth+AxProtWidth+:AxRegionWidth] = s_arregion;
+  assign m_raddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+AxCacheWidth+AxProtWidth+:AxRegionWidth] = m_arregion;
+  assign s_raddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+AxCacheWidth+AxProtWidth+AxRegionWidth+:AxQoSWidth] = s_arqos;
+  assign m_raddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+AxCacheWidth+AxProtWidth+AxRegionWidth+:AxQoSWidth] = m_arqos;
+  // assign s_raddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+AxCacheWidth+AxProtWidth+AxRegionWidth+AxQoSWidth+:AxUserWidth] = s_aruser;
+  // assign m_raddr_internal[IDWidth+AxAddrWidth+AxLenWidth+AxSizeWidth+AxBurstWidth+AxLockWidth+AxCacheWidth+AxProtWidth+AxRegionWidth+AxQoSWidth+:AxUserWidth] = m_aruser;
+
+  assign s_wdata_internal[0+:MaxBurstEffSizeBits] = s_wdata;
+  assign m_wdata_internal[0+:MaxBurstEffSizeBits] = m_wdata;
+  assign s_wdata_internal[MaxBurstEffSizeBits+:WStrbWidth] = s_wstrb;
+  assign m_wdata_internal[MaxBurstEffSizeBits+:WStrbWidth] = m_wstrb;
+  assign s_wdata_internal[MaxBurstEffSizeBits+WStrbWidth+:XLastWidth] = s_wlast;
+  assign m_wdata_internal[MaxBurstEffSizeBits+WStrbWidth+:XLastWidth] = m_wlast;
+
+  assign s_rdata_internal[0+:IDWidth] = s_rid;
+  assign m_rdata_internal[0+:IDWidth] = m_rid;
+  assign s_rdata_internal[IDWidth+:MaxBurstEffSizeBits] = s_rdata;
+  assign m_rdata_internal[IDWidth+:MaxBurstEffSizeBits] = m_rdata;
+  assign s_rdata_internal[IDWidth+MaxBurstEffSizeBits+:XRespWidth-1] = s_rresp;
+  assign m_rdata_internal[IDWidth+MaxBurstEffSizeBits+:XRespWidth-1] = m_rresp;
+  assign s_rdata_internal[IDWidth+MaxBurstEffSizeBits+XRespWidth-1+:XLastWidth] = s_rlast;
+  assign m_rdata_internal[IDWidth+MaxBurstEffSizeBits+XRespWidth-1+:XLastWidth] = m_rlast;
+
+  assign s_wrsp_internal[0+:IDWidth] = s_bid;
+  assign m_wrsp_internal[0+:IDWidth] = m_bid;
+  assign s_wrsp_internal[IDWidth+:XRespWidth-1] = s_bresp;
+  assign m_wrsp_internal[IDWidth+:XRespWidth-1] = m_bresp;
+
+  simmem_top i_simmem_top (
+      .clk_i            (clk_i),
+      .rst_ni           (rst_ni),
+      .raddr_in_valid_i (s_arvalid),
+      .raddr_out_ready_i(m_arready),
+      .raddr_in_ready_o (s_arready),
+      .raddr_out_valid_o(m_arvalid),
+      .waddr_in_valid_i (s_awvalid),
+      .waddr_out_ready_i(m_awready),
+      .waddr_in_ready_o (s_awready),
+      .waddr_out_valid_o(m_awvalid),
+      .wdata_in_valid_i (s_wvalid),
+      .wdata_out_ready_i(m_wready),
+      .wdata_in_ready_o (s_wready),
+      .wdata_out_valid_o(m_wvalid),
+      .rdata_in_valid_i (m_rvalid),
+      .rdata_out_ready_i(s_rready),
+      .rdata_in_ready_o (m_rready),
+      .rdata_out_valid_o(s_rvalid),
+      .wrsp_in_valid_i  (m_bvalid),
+      .wrsp_out_ready_i (s_bready),
+      .wrsp_in_ready_o  (m_bready),
+      .wrsp_out_valid_o (s_bvalid),
+      .raddr_i          (s_raddr_internal),
+      .waddr_i          (s_waddr_internal),
+      .wdata_i          (s_wdata_internal),
+      .rdata_i          (m_rdata_internal),
+      .wrsp_i           (m_wrsp_internal),
+      .raddr_o          (m_raddr_internal),
+      .waddr_o          (m_waddr_internal),
+      .wdata_o          (m_wdata_internal),
+      .rdata_o          (s_rdata_internal),
+      .wrsp_o           (s_wrsp_internal)
+  );
+
+endmodule

--- a/vivado_integration.md
+++ b/vivado_integration.md
@@ -1,0 +1,168 @@
+# Vivado integration of the simulated memory controller
+
+This document briefly shows how to integrate the simulated memory controller in a Xilinx Vivado design, using a Microblaze core as a CPU core example on a Digilent Nexys Video board.
+
+## Project creation
+
+Create a new RTL project and include the RTL files.
+
+![](https://i.imgur.com/t6Kxp2i.png)
+
+No constraints are required in this step.
+
+![](https://i.imgur.com/RfOJVkH.png)
+
+Choose your board.
+
+![](https://i.imgur.com/89ldrKz.png)
+
+## IP packaging
+
+Create a new block design, called _simmem_module_.
+
+![](https://i.imgur.com/toL8jK1.png)
+
+Add the Verilog wrapper to the empty block design.
+
+![](https://i.imgur.com/gjbnPWM.png)
+
+Make all the pins external.
+
+![](https://i.imgur.com/QZVPwjJ.png)
+
+Package the new IP through _tools -> Create and package new IP_.
+
+![](https://i.imgur.com/PJRZZoz.png)
+
+![](https://i.imgur.com/18wVXCn.png)
+
+## Main block design
+
+### Microblaze placement
+
+Create a new block design _simmem_ublaze_.
+
+Import the clock wizard to output a clock frequency of 200MHz and take an active low signal.
+
+![](https://i.imgur.com/grdKWB0.png)
+
+![](https://i.imgur.com/a1ttVvO.png)
+
+Import a DDR3 MIG and connect its clock input to the clock wizard's output. Then, run the connection automation.
+
+![](https://i.imgur.com/cxbJql3.png)
+
+Create a Microblaze IP and run block automation.
+
+![](https://i.imgur.com/SACtEFS.png)
+![](https://i.imgur.com/98brV9N.png)
+![](https://i.imgur.com/I08IdeL.png)
+![](https://i.imgur.com/FS8pFKA.png)
+![](https://i.imgur.com/xWRtzOX.png)
+
+Add an UART module and connect its interrupt output to the interrupt controller input.
+Then, run connection automation, regenerate the layout and validate the design.
+
+![](https://i.imgur.com/DyIFkMs.png)
+
+### Simmem insertion
+
+Delete the AXI link between the AXI interconnect and the DDR3 MIG.
+
+![](https://i.imgur.com/crJilAG.png)
+
+Insert a simulated memory controller IP. Connect the clock and reset inputs to the corresponding inputs of the AXI interconnect.
+
+![](https://i.imgur.com/nDEmgOf.png)
+
+Then, regenerate the layout and validate the design.
+
+### Address mapping
+
+Replace the mapping of the MIG by the simulated memory controller. Additionally, map the MIG in the memory controller's addresses.
+
+![](https://i.imgur.com/oWzVkja.png)
+
+### Integrated Logic Analyzer insertion (optional)
+
+Insert two new ILA instances as shown in the figures below.
+These will examine the AXI traffic around the simulated memory controller.
+
+![](https://i.imgur.com/ssnY8ne.png)
+![](https://i.imgur.com/4E2EGPD.png)
+
+## Bitstream generation
+
+### Top module selection
+
+Create a HDL wrapper around _simmem_ublaze_.
+
+![](https://i.imgur.com/kZ8nUSm.png)
+![](https://i.imgur.com/fzQOFPj.png)
+
+Then, set this wrapper as top.
+The result should be as in the figure below.
+
+![](https://i.imgur.com/99qpc1L.png)
+
+
+### Bitstream
+
+Now generate the bitstream.
+
+First, run the synthesis.
+
+![](https://i.imgur.com/oWzVkja.png)
+
+
+## Execution
+
+### Hardware exportation
+
+Open the target and program the device.
+
+![](https://i.imgur.com/9Bv8uLT.png)
+
+Export the hardware under _File -> Export -> Export Hardware..._.
+
+![](https://i.imgur.com/z3zirr1.png)
+
+Open the SDK under _File -> Launch SDK_.
+
+![](https://i.imgur.com/8oDC4tE.png)
+
+### SDK: Memory testing application
+
+#### Application setup
+
+Verify the displayed address mappings in the SDK window.
+
+![](https://i.imgur.com/B9vc6RG.png)
+
+Create a new project under _File -> New -> Application Project_.
+
+![](https://i.imgur.com/PiOO30P.png)
+![](https://i.imgur.com/ny6JHU6.png)
+
+Configure the memory test as in the figure below.
+
+![](https://i.imgur.com/X1W9j09.png)
+![](https://i.imgur.com/nnrD2Je.png)
+
+#### UART terminal setup
+
+Open the _SDK terminal_ tab.
+
+![](https://i.imgur.com/WHuflL7.png)
+
+Click the green + button. Select a baud rate of 9600 and click OK.
+
+![](https://i.imgur.com/4pvyJkh.png)
+
+#### Application run
+
+Run the application under _Run -> Run configurations..._
+
+![](https://i.imgur.com/0ofurRw.png)
+
+Finally, run the application.


### PR DESCRIPTION
This PR follows integration tests on Xilinx Vivado, mostly:
* A Verilog wrapper. Apparently, Verilog does not support SystemVerilog package imports or structures, therefore those are implemented on binary arrays.
* Corrections in fields and field widths.

This passes basic tests in Vivado: writing and reading arrays in the memory mapped to the simulated memory controller. The operation is confirmed by waveform inspection using an Integrated Logic Analyzer.