### PR TITLE
fusesoc.conf: remove

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # fusesoc result and build directories with special suffixes
 build/
+fusesoc.conf
 
 # Simulation Results
 *.log

--- a/fusesoc.conf
+++ b/fusesoc.conf
@@ -1,6 +1,0 @@
-[library.simmem]
-location = /home/ppr/gsoc/gsoc-sim-mem
-sync-uri = .
-sync-type = local
-auto-sync = true
-


### PR DESCRIPTION
Hello!

Sorry, I just realized that I had mistakenly left the fusesoc.conf file in the repo.
This PR removes it for comfort.